### PR TITLE
Fix missing port on deployment container spec

### DIFF
--- a/chapter_04/assets/manifests/nginx_deployment.yaml
+++ b/chapter_04/assets/manifests/nginx_deployment.yaml
@@ -18,3 +18,6 @@ spec:
       containers:
         - name: "nginx"
           image: "nginx:latest"
+          ports:
+            - containerPort: 8080
+              name: nginx


### PR DESCRIPTION
Missing a containerPort in the example raising:

```
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0
```

This PR fixes the YAML template